### PR TITLE
Add patched version to sweet_xml vulnerability (CVE-2019-15160)

### DIFF
--- a/packages/sweet_xml/2019-08-19.yml
+++ b/packages/sweet_xml/2019-08-19.yml
@@ -11,3 +11,4 @@ description: |
   The SweetXml (aka sweet_xml) package through 0.6.6 for Erlang and Elixir allows attackers to cause a denial of service (resource consumption) via an XML entity expansion attack with an inline DTD.
 
 patched_versions:
+  - ">= 7.0.0"


### PR DESCRIPTION
The `sweet_xml` vulnerability CVE-2019-15160 was [fixed in v7.0.0](https://github.com/kbrw/sweet_xml/issues/71#issuecomment-901770808). This PR adds the corresponding patched version to the package configuration.