### PR TITLE
Fix patched version of sweet_xml vulnerability (CVE-2019-15160)

### DIFF
--- a/packages/sweet_xml/2019-08-19.yml
+++ b/packages/sweet_xml/2019-08-19.yml
@@ -11,4 +11,4 @@ description: |
   The SweetXml (aka sweet_xml) package through 0.6.6 for Erlang and Elixir allows attackers to cause a denial of service (resource consumption) via an XML entity expansion attack with an inline DTD.
 
 patched_versions:
-  - ">= 7.0.0"
+  - ">= 0.7.0"


### PR DESCRIPTION
Fix the incorrect patched version in #32.

Sorry about that.